### PR TITLE
Force front-end processing to always use 3 patch-match iterations whe…

### DIFF
--- a/apps/DensifyPointCloud/DensifyPointCloud.cpp
+++ b/apps/DensifyPointCloud/DensifyPointCloud.cpp
@@ -109,6 +109,11 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 		#endif
 		;
 
+	// Previously, the _USE_CUDA pathway set numIters to 4 by default.
+	// This has the effect of forcing the CPU to 4 patch-match iterations when
+	// CUDA use is compiled in AND CPU processing is enabled.
+	// Now we default both to DPC_NUM_ITERS (3) and the CUDA path
+	// will manually set this to 4 in CUDA-specific code.
 #ifdef FORCIBLY_DISABLE_CUDA
 	const unsigned nNumViewsDefault(5);
 	const unsigned numIters(DPC_NUM_ITERS);
@@ -116,7 +121,7 @@ bool Initialize(size_t argc, LPCTSTR* argv)
 	// group of options allowed both on command line and in config file
 	#ifdef _USE_CUDA
 	const unsigned nNumViewsDefault(8);
-	const unsigned numIters(4);
+	const unsigned numIters(DPC_NUM_ITERS);
 	#else
 	const unsigned nNumViewsDefault(5);
 	const unsigned numIters(DPC_NUM_ITERS);

--- a/libs/MVS/PatchMatchCUDA.cpp
+++ b/libs/MVS/PatchMatchCUDA.cpp
@@ -101,7 +101,8 @@ void PatchMatchCUDA::Init(bool bGeomConsistency)
 		params.nEstimationIters = 1;
 	} else {
 		params.bGeomConsistency = false;
-		params.nEstimationIters = OPTDENSE::nEstimationIters;
+		// JPB WIP No good way to set this to correspond with the original setting.
+		params.nEstimationIters = 4; // OPTDENSE::nEstimationIters;
 	}
 }
 

--- a/libs/MVS/SceneDensify.cpp
+++ b/libs/MVS/SceneDensify.cpp
@@ -882,6 +882,20 @@ bool DepthMapsData::EstimateDepthMap(IIndex idxImage, int nGeometricIter)
 	_controlfp_s(NULL, _DN_FLUSH, _MCW_DN);
 #endif
 
+	static bool firstTime = true;
+	if (firstTime) {
+		bool usingGPU = false;
+#ifdef _USE_CUDA
+		usingGPU = pmCUDA;
+#endif
+		if (usingGPU) {
+			VERBOSE("Running patch-matching on a CUDA-enabled GPU.");
+		} else {
+			VERBOSE("Running patch-matching on the CPU.");
+		}
+		firstTime = false;
+	}
+
 	#ifdef _USE_CUDA
 	if (pmCUDA) {
 		pmCUDA->EstimateDepthMap(arrDepthData[idxImage]);


### PR DESCRIPTION
…n the CPU is chosen for processing (even if USE_CUDA is enabled and processing falls back to the CPU).  CUDA/GPU pathway continues to use 4 patch-match iterations if used.

Add a message to the log to help identify this.