### PR TITLE
Added a control to make the Viewer project optional

### DIFF
--- a/apps/Viewer/CMakeLists.txt
+++ b/apps/Viewer/CMakeLists.txt
@@ -2,6 +2,10 @@ if((NOT OpenMVS_USE_OPENGL) OR (NOT _USE_OPENGL))
 	RETURN()
 endif()
 
+if (NO_VIEWER)
+	RETURN()
+endif()
+
 if(NOT VIEWER_NAME)
 	set(VIEWER_NAME "Viewer")
 endif()


### PR DESCRIPTION
Since the Jenkins pipeline hits a couple of linker errors when trying to build the Viewer project, I added a new CMake control called NO_VIEWER which does exactly what it sounds like. I'm going to enable this control on the Jenkins job since we don't need the viewer for this.